### PR TITLE
1.6.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.6.0 (2024-10-24)
+
+#### Feature
+
+  - Added `application_name` as one of the fields returned by the primary activity proxy model by [@Pete-J-Matthews](https://github.com/Pete-J-Matthews) in [#11](https://github.com/Opus10/django-pgactivity/pull/11).
+
 ## 1.5.0 (2024-08-24)
 
 #### Changes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ packages = [
 exclude = [
   "*/tests/"
 ]
-version = "1.5.0"
+version = "1.6.0"
 description = "Monitor, kill, and analyze Postgres queries."
 authors = ["Wes Kendall"]
 classifiers = [


### PR DESCRIPTION
Adds `application_name` as one of the tracked fields in the main proxy model